### PR TITLE
Update `README` for directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,18 +75,24 @@ Refer to the tool documentation for usage instructions tailored to your preferre
 
 ## Versioned Specifications
 
-Specific versions of the Pinecone API are released using git tags and [releases](https://github.com/pinecone-io/pinecone-api/releases) in this repository. New versions of the Pinecone API are released quarterly. You can find more about API versioning [here](https://docs.pinecone.io/reference/api/versioning). Tags are named using the `YYYY-MM` format, corresponding to the year and month of the release.
+Each subdirectory in this repository represents a specific version of the Pinecone API. New versions of the Pinecone API are released quarterly. You can find more about API versioning [here](https://docs.pinecone.io/reference/api/versioning).
+Directories are named using the `YYYY-MM` format, corresponding to the year and month of the release.
+The API resources corresponding to each version are inside of their respective directory, and will have the format `<resource_name>_<api_version>.<file_extension>`.
 
-Example ([tag](https://github.com/pinecone-io/pinecone-api/tree/2024-10): `2024-10`):
+Example:
 
 ```
-pinecone-io/pinecone-api:2024-10/
-  - .gitignore
-  - README.md
-  - db_control.oas.yaml
-  - db_data.oas.yaml
-  - db_data.proto
-  - inference.oas.yaml
+2025-04/
+- admin_2025-04.oas.yaml
+- assistant_control_2025-04.oas.yaml
+- assistant_data_2025-04.oas.yaml
+- assistant_evaluation_2025-04.oas.yaml
+- db_control_2025-04.oas.yaml
+- db_data_2025-04.oas.yaml
+- db_data_2025-04.proto
+- db_metrics_2025-04.oas.yaml
+- inference_2025-04.oas.yaml
+- oauth_2025-04.oas.yaml
 ```
 
 - **OpenAPI Files**: Files with the extension `*.oas.yaml`.
@@ -96,18 +102,16 @@ pinecone-io/pinecone-api:2024-10/
 
 ## Service-Specific Breakdown
 
-The Pinecone API consists of multiple services. Below is a high-level breakdown of the services and the associated specification files.
+The Pinecone API consists of multiple services. Below is a high-level breakdown of some of these services and the associated specification files, and documentation links. The defined services will change across time and versions. You can use the `X-Pinecone-API-Version` header to work with a [specific version](https://docs.pinecone.io/reference/api/versioning#specify-an-api-version).
 
-Note: The database service is split into "control" and "data" specifications. Control handles managing database resources such as indexes and collections and uses REST. Data defines interaction with a specific index resource and uses gRPC or REST.
-
-| Service                | OpenAPI File                    | Protobuf File   | Documentation Link                                                                           |
-| ---------------------- | ------------------------------- | --------------- | -------------------------------------------------------------------------------------------- |
-| Database - Control     | `db_control.oas.yaml`           | N/A             | [Database Documentation](https://docs.pinecone.io/reference/api/introduction#database-api)   |
-| Database - Data        | `db_data.oas.yaml`              | `db_data.proto` | [Database Documentation](https://docs.pinecone.io/reference/api/introduction#database-api)   |
-| Inference              | `inference.oas.yaml`            | N/A             | [Inference Documentation](https://docs.pinecone.io/reference/api/introduction#inference-api) |
-| Assistant - Control    | `assistant_control.oas.yaml`    | N/A             | [Assistant Documentation](https://docs.pinecone.io/reference/api/introduction#assistant-api) |
-| Assistant - Data       | `assistant_data.oas.yaml`       | N/A             | [Assistant Documentation](https://docs.pinecone.io/reference/api/introduction#assistant-api) |
-| Assistant - Evaluation | `assistant_evaluation.oas.yaml` | N/A             | [Assistant Documentation](https://docs.pinecone.io/reference/api/introduction#assistant-api) |
+| Service                | OpenAPI File                            | Protobuf File           | Documentation Link                                                                           |
+| ---------------------- | --------------------------------------- | ----------------------- | -------------------------------------------------------------------------------------------- |
+| Database - Control     | `db_control_2025-04.oas.yaml`           | N/A                     | [Database Documentation](https://docs.pinecone.io/reference/api/introduction#database-api)   |
+| Database - Data        | `db_data_2025-04.oas.yaml`              | `db_data_2025-04.proto` | [Database Documentation](https://docs.pinecone.io/reference/api/introduction#database-api)   |
+| Inference              | `inference_2025-04.oas.yaml`            | N/A                     | [Inference Documentation](https://docs.pinecone.io/reference/api/introduction#inference-api) |
+| Assistant - Control    | `assistant_control_2025-04.oas.yaml`    | N/A                     | [Assistant Documentation](https://docs.pinecone.io/reference/api/introduction#assistant-api) |
+| Assistant - Data       | `assistant_data_2025-04.oas.yaml`       | N/A                     | [Assistant Documentation](https://docs.pinecone.io/reference/api/introduction#assistant-api) |
+| Assistant - Evaluation | `assistant_evaluation_2025-04.oas.yaml` | N/A                     | [Assistant Documentation](https://docs.pinecone.io/reference/api/introduction#assistant-api) |
 
 You can find specific links and resources for each service in the [Pinecone API reference](https://docs.pinecone.io/reference/api/introduction). Note: The names of the files may differ across versions.
 


### PR DESCRIPTION
## Problem
Instead of using git tags to denote API versions, we're going to use versioned directories at the top level of this repo. The upstream CI workflow has been updated and we've already ported the changes over to `pinecone-api` - we just need to update the `README`.

## Solution
Update the `README` to explain the versioned directory structure.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
N/A
