### PR TITLE
Update assistant metadata field descriptions to document 16KB limit

### DIFF
--- a/2025-10/assistant_control_2025-10.oas.yaml
+++ b/2025-10/assistant_control_2025-10.oas.yaml
@@ -112,6 +112,7 @@ paths:
                   description: Description or directive for the assistant to apply to all responses.
                   type: string
                 metadata:
+                  description: Optional metadata associated with the assistant. Metadata is a JSON object that can store custom organizational data, tags, and attributes. Maximum size is 16KB.
                   type: object
                 region:
                   description: The region to deploy the assistant in. Our current options are either us or eu. Defaults to us.
@@ -362,6 +363,7 @@ paths:
                   description: Description or directive for the assistant to apply to all responses.
                   type: string
                 metadata:
+                  description: Optional metadata associated with the assistant. Metadata is a JSON object that can store custom organizational data, tags, and attributes. Maximum size is 16KB.
                   nullable: true
                   type: object
         required: true
@@ -379,6 +381,7 @@ paths:
                     description: Description or directive for the assistant to apply to all responses.
                     type: string
                   metadata:
+                    description: Optional metadata associated with the assistant. Metadata is a JSON object that can store custom organizational data, tags, and attributes.
                     type: object
         '400':
           description: Bad Request
@@ -459,6 +462,7 @@ components:
           description: Description or directive for the assistant to apply to all responses.
           type: string
         metadata:
+          description: Optional metadata associated with the assistant. Metadata is a JSON object that can store custom organizational data, tags, and attributes.
           nullable: true
           type: object
         status:


### PR DESCRIPTION
## Problem

The assistant metadata limit was increased from 1KB to 16KB in the implementation, but the OpenAPI specification did not document this limit. Users need to know the current metadata size limit when creating or updating assistants. Additionally, metadata field descriptions were missing from several schemas in the specification.

## Solution

Updated the `assistant_control_2025-10.oas.yaml` specification to:
- Add metadata field descriptions with the 16KB limit to entry schemas where users input data (`CreateAssistant` request and `UpdateAssistant` request)
- Add metadata field descriptions without the limit to response schemas and the shared `Assistant` component schema (to avoid tying implementation-specific limits to consumed schemas)

This approach documents the limit where users need it (when sending data) while keeping the shared model implementation-agnostic.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Previewed locally.