### PR TITLE
Fix `query_string` fields

### DIFF
--- a/202601-alpha/db_data_202601-alpha.oas.yaml
+++ b/202601-alpha/db_data_202601-alpha.oas.yaml
@@ -2378,10 +2378,10 @@ components:
         A scoring method that defines how documents are scored against a query.
 
         The `type` field determines which other fields are used:
-        - `dense_vector`: Score by dense vector similarity. Requires `field` and a `values` array.
-        - `sparse_vector`: Score by sparse vector similarity. Requires `field` and `sparse_values`.
-        - `text`: Score by BM25 text similarity against a single field. Requires `field` and `query`.
-        - `query_string`: Score using a query string against all full-text-searchable fields. Requires `query`. Optionally restrict the query to a single full-text-searchable field using `field`.
+        - `dense_vector`: Score by dense vector similarity. Requires `field` or `fields`, and a `values` array.
+        - `sparse_vector`: Score by sparse vector similarity. Requires `field` or `fields`, and `sparse_values`.
+        - `text`: Score by BM25 text similarity against a single field. Requires `field` or `fields`, and `query`.
+        - `query_string`: Score using a Lucene query string. Use field qualifiers (`field:(clause)`) to target a field, or omit field qualifiers to search against all text-searchable fields. Errors if `field` or `fields` is provided.
       type: object
       properties:
         type:
@@ -2397,8 +2397,8 @@ components:
         field:
           description: |-
             The field to score against.
-
-            Required for `dense_vector`, `sparse_vector`, and `text` scoring types. For `query_string`, optionally restricts the query to this field; when omitted, the query runs against all full-text-searchable fields.
+            
+            Required for `dense_vector`, `sparse_vector`, and `text` scoring types. Must not be provided for `query_string`. 
           type: string
         query:
           description: The text query to use for `text` and `query_string` scoring types.


### PR DESCRIPTION
## Problem

`field` or `fields` fields must not be provided in `query_string` `score_by` objects.

## Solution

Describe the approach you took. Link to any relevant bugs, issues, docs, or other resources.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
