### PR TITLE
fix: correct the API-version header name in the Nexus spec

### DIFF
--- a/2026-07/nexus_2026-07.oas.yaml
+++ b/2026-07/nexus_2026-07.oas.yaml
@@ -5098,7 +5098,7 @@ components:
     ApiVersionHeader:
       in: header
       name: X-Pinecone-Api-Version
-      description: Date-based contract version. Omit to resolve to the default version (`2026-07`, the
+      description: Date-based contract version. Omit to resolve to the Nexus default version (`2026-07`, the
         oldest served version); send `unstable` for the in-development surface. The resolved version is
         echoed back on the same header. A present-but-unrecognized value is rejected with `400
         unsupported_api_version`.

--- a/2026-07/nexus_2026-07.oas.yaml
+++ b/2026-07/nexus_2026-07.oas.yaml
@@ -5097,10 +5097,11 @@ components:
   parameters:
     ApiVersionHeader:
       in: header
-      name: X-Pinecone-API-Version
-      description: Date-based contract version. Omit to resolve to the oldest served version (`2026-07`);
-        send `unstable` for the in-development surface. The resolved version is echoed back on the same
-        header. A present-but-unrecognized value is rejected with `400 unsupported_api_version`.
+      name: X-Pinecone-Api-Version
+      description: Date-based contract version. Omit to resolve to the default version (`2026-07`, the
+        oldest served version); send `unstable` for the in-development surface. The resolved version is
+        echoed back on the same header. A present-but-unrecognized value is rejected with `400
+        unsupported_api_version`.
       required: false
       style: simple
       schema:


### PR DESCRIPTION
Renames the Nexus spec's version header to `X-Pinecone-Api-Version` to match every other spec in this repo, and states explicitly that omitting it resolves to the default version, `2026-07`.